### PR TITLE
Code snippet preview now properly hides the preview tiggering classname

### DIFF
--- a/styleguide/structure/scripts/iframe.js
+++ b/styleguide/structure/scripts/iframe.js
@@ -72,7 +72,8 @@ var StyleguideIframe = {
       };
 
     $(this.codeToCreateSnippetClass).each(function(i, obj) {
-      var snippet = tidy_html5($(obj).get(0).outerHTML.replace(' ' + this.codeToCreateSnippetClass, '').replace(this.codeToCreateSnippetClass, ''), options);
+      var snippetClassName = _this.codeToCreateSnippetClass.replace(/\./g, '');
+      var snippet = tidy_html5($(obj).get(0).outerHTML.replace(' ' + snippetClassName, '').replace(snippetClassName, ''), options);
 
       $(obj).before('<a href="#" class="' + _this.codeSnippetsClass.replace('.', '') + '"></a>');
       $(obj).after('<pre class="language-markup"><code>' + $('<p/>').text(snippet).html() + '</code></pre>').next().hide();


### PR DESCRIPTION
Original code wasn't accessing the top level "codeToCreateSnippetClass", since it was running inside the each loop and wasn't proxied, so "this" pointed to the jQuery element. Also, _this."codeToCreateSnippetClass" returns the classname with the period at the beginning, but we don't need that, since the outerHTML does not include that and the replace will fail. Thus why it is regexped out.