### PR TITLE
Use placeholder selectors instead of class selectors

### DIFF
--- a/styleguide/structure/styles/_base/_typography.scss
+++ b/styleguide/structure/styles/_base/_typography.scss
@@ -1,3 +1,12 @@
+%module__title {
+  font-size: 30px;
+  line-height: 30px;
+  margin: 0 0 45px;
+  font-weight: normal;
+  color: #555;
+  -webkit-font-smoothing: antialiased;
+}
+
 a {
   color: #333;
 }
@@ -10,19 +19,14 @@ p.huge-module__paragraph {
 }
 
 .huge-module__title {
-  font-size: 30px;
-  line-height: 30px;
-  margin: 0 0 45px;
-  font-weight: normal;
-  color: #555;
-  -webkit-font-smoothing: antialiased;
-}
+  @extend %module__title;
 
-.huge-module__title--small {
-  @extend .huge-module__title;
-  font-size: 20px;
-  line-height: 20px;
-  margin-bottom: 25px;
+  &--small {
+    @extend %module__title;
+    font-size: 20px;
+    line-height: 20px;
+    margin-bottom: 25px;
+  }
 }
 
 .huge-module__title--light {

--- a/styleguide/structure/styles/_base/_typography.scss
+++ b/styleguide/structure/styles/_base/_typography.scss
@@ -1,3 +1,4 @@
+// Module title placeholder
 %module__title {
   font-size: 30px;
   line-height: 30px;
@@ -27,14 +28,14 @@ p.huge-module__paragraph {
     line-height: 20px;
     margin-bottom: 25px;
   }
-}
 
-.huge-module__title--light {
-  color: #bbb;
-  text-transform: none;
-  margin: 0;
-  font-size: 12px;
-  line-height: 12px;
-  margin-bottom: 25px;
-  font-weight: normal;
+  &--light {
+    color: #bbb;
+    text-transform: none;
+    margin: 0;
+    font-size: 12px;
+    line-height: 12px;
+    margin-bottom: 25px;
+    font-weight: normal;
+  }
 }


### PR DESCRIPTION
When we use class selectors as placeholder to insert new CSS properties through the `@extend` keyword, we create unnecessary duplicated class selectors in the output CSS, adding a lot of weight *(specificity)* to our selectors, making them hard to override.

It is recommended to user placeholders selectors instead so the output generated have single selectors without duplicated properties.

**The Sass Way:** [Understanding placeholder selectors](http://thesassway.com/intermediate/understanding-placeholder-selectors)