### PR TITLE
Fix missing space Harp's compilation error

### DIFF
--- a/styleguide/modules/3_typography/_typography.jade
+++ b/styleguide/modules/3_typography/_typography.jade
@@ -5,8 +5,7 @@ if items.intro
 .titles
 	each font in items.fonts
 		- var heading = '<h' + font.heading + ' class="' + font.className + '">' + font.title + '</h' + font.heading + '>'
-		h4.huge-module__title--light #{font.fontName} - #{font.fontSize}
-		!{heading}
+		h4.huge-module__title--light #{font.fontName} - #{font.fontSize} !{heading}
 br
 h5.huge-module__title--small=items.paragraphsName
 each paragraph in items.paragraphs


### PR DESCRIPTION
The Harp's compilation process is sending a warning about a missing space.

```
Warning: missing space before text for line 9 of jade file "/Users/dave/Development/huge/styleguide/styleguide/modules/3_typography/_typography.jade"
```

This is cause by an extra and unnecessary return in the **Jade** file.