### PR TITLE
fix download link

### DIFF
--- a/start.html
+++ b/start.html
@@ -24,7 +24,7 @@
 <a href="https://github.com/hugeinc/styleguide/archive/master.zip" class="button primary">Download for Mac</a></div></div></div></div><div id="windows-linux" class="section u-cf inner"><div class="container"><div class="row"><div class="ten columns center"><h2 class="title">Windows/Linux</h2><p>Sorry! We currently don&#39;t have any &#39;magical&#39; app for these platforms. We&#39;re working on that.</p>
 <p>To use the Styleguide you&#39;ll need to execute a couple of commands in the command-line.</p>
 <p>*<a href="#manual-install">Check the &quot;Manual Install&quot;</a> section.</p>
-<a href="https://github.com/hugeinc/styleguide/archive/windows-linux.zip" class="button primary">Download for Windows/Linux</a></div></div></div></div><div id="manual-install" class="section u-cf inner"><div class="container"><div class="row"><div class="ten columns center"><h2 class="title">Manual installation</h2><p>This project has the following dependencies (click to install each of them):</p>
+<a href="https://github.com/hugeinc/styleguide/archive/release/windows-linux.zip" class="button primary">Download for Windows/Linux</a></div></div></div></div><div id="manual-install" class="section u-cf inner"><div class="container"><div class="row"><div class="ten columns center"><h2 class="title">Manual installation</h2><p>This project has the following dependencies (click to install each of them):</p>
 <ul>
 <li><a href="http://nodejs.org" target="_blank">Node.js</a></li>
 <li><a href="http://harpjs.com" target="_blank">Harp.js</a></li>


### PR DESCRIPTION
Windows / Linux download link fixed
`https://github.com/hugeinc/styleguide/archive/windows-linux.zip`
replaced by
`https://github.com/hugeinc/styleguide/archive/release/windows-linux.zip`
ref #54 