### PR TITLE
Updated harp version in package.json

### DIFF
--- a/styleguide/structure/_node-files/package.json
+++ b/styleguide/structure/_node-files/package.json
@@ -7,7 +7,7 @@
     "livereload": "0.4.1",
     "watch": "0.18.0",
     "command-exists": "1.0.2",
-    "harp": "0.20.3",
+    "harp": "0.23.0",
     "js-beautify": "1.6.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Bumped harp to v0.23.0 (current as of this commit) - fixes version incompatibility with node / node-sass, previously breaking `npm install`.